### PR TITLE
Log table modification

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -299,6 +299,17 @@ def explain():
     )
     predicted_score = df_y['score_tot_prediction'].iloc[0]
 
+    # Log predicted score
+    new_log = Log(
+        timestamp=datetime.now(timezone.utc),
+        log_type='score_computation',
+        log_info=predicted_score,
+        user_id=current_user.user_id,
+        phase_id='explain'
+        )
+    db.session.add(new_log)
+    db.session.commit()
+
     # Extract additional info
     ## 1 - regression coefficient
     coefficients = best_model.named_steps["regressor"].coef_

--- a/app/models.py
+++ b/app/models.py
@@ -122,10 +122,10 @@ class Log(db.Model):
     user_id: so.Mapped[str] = so.mapped_column(sa.ForeignKey(User.user_id),index=True)
     participant: so.Mapped['User'] = so.relationship(back_populates='logs')
 
-    question_id: so.Mapped[str] = so.mapped_column(sa.ForeignKey(Question.question_id),index=True)
+    question_id: so.Mapped[Optional[str]] = so.mapped_column(sa.ForeignKey(Question.question_id),index=True)
     question: so.Mapped['Question'] = so.relationship(back_populates='logs')
 
-    answer_id: so.Mapped[str] = so.mapped_column(sa.ForeignKey(Answer.answer_id),index=True)
+    answer_id: so.Mapped[Optional[str]] = so.mapped_column(sa.ForeignKey(Answer.answer_id),index=True)
     answer: so.Mapped['Answer'] = so.relationship(back_populates='logs')
 
     phase_id: so.Mapped[str] = so.mapped_column(sa.String(64))

--- a/app/models.py
+++ b/app/models.py
@@ -138,6 +138,10 @@ class Log(db.Model):
     phase_id: so.Mapped[str] = so.mapped_column(sa.String(64))
 
     def __repr__(self):
-        return f'{self.timestamp} - Q:{self.question_id} - A:{self.answer_id}'
-
+        if self.log_type=='answer':
+            return f'{self.timestamp} - User:{self.user_id} - Q:{self.question_id} - A:{self.answer_id}'
+        elif self.log_type=='score_computation':
+            return f'{self.timestamp} - User:{self.user_id} - Phase:{self.phase_id} - Score:{self.log_info}'
+        else:
+            return f'{self.timestamp} - User:{self.user_id} - Type:{self.log_type} - Info:{self.log_info}'
 

--- a/app/models.py
+++ b/app/models.py
@@ -119,6 +119,13 @@ class Log(db.Model):
     timestamp: so.Mapped[datetime] = so.mapped_column(
         index=True, default=lambda: datetime.now(timezone.utc))
     
+    # Type of log: answer, score_computation
+    # By default, it is an answer to a question
+    log_type: so.Mapped[str] = so.mapped_column(sa.String(64), default='answer')
+
+    # Additionnal info about the log
+    log_info: so.Mapped[Optional[str]] = so.mapped_column(sa.String(64))
+    
     user_id: so.Mapped[str] = so.mapped_column(sa.ForeignKey(User.user_id),index=True)
     participant: so.Mapped['User'] = so.relationship(back_populates='logs')
 


### PR DESCRIPTION
In class Log:
- answer_id and question_id optional
- add log_type informing the type of log, by default it is 'answer' when we log a question with the answer, we can also have 'score_computation' if it is the computation of a score
- add log_info allowing extra information about the log. When log_type is 'score_computation', we will have the score computed in log_info
- modify the representation of a log

In routes explain:
- log the score computed