### PR TITLE
Restructure each explain type

### DIFF
--- a/app/templates/main/disclaimer.html
+++ b/app/templates/main/disclaimer.html
@@ -1,0 +1,6 @@
+
+<br><br>
+{# — Disclaimer — #}
+<p style="font-size: 0.85em; color: #555;">
+    <strong>Disclaimer</strong>: The insights provided here are based on the algorithm trained in our pilot study and are not intended to replace professional advice. For any concerns about your mental health, we encourage you to speak with a qualified healthcare provider. Here is a link to available support resources: <strong><a href="https://www.ccmhs-ccsms.ca/education/mh-resources-en" target="_blank">Resources</a></strong>
+</p>

--- a/app/templates/main/explain_baseline.html
+++ b/app/templates/main/explain_baseline.html
@@ -12,6 +12,7 @@
             <td ALIGN="LEFT">
                 {% set gauge_score = explain_dic.predicted_score %}
                 {% include 'main/explain_intro_and_gauge.html' %}
+                {% include 'main/disclaimer.html' %}
             </td>
         </tr>
     </table>

--- a/app/templates/main/explain_baseline.html
+++ b/app/templates/main/explain_baseline.html
@@ -11,7 +11,7 @@
         <tr> 
             <td ALIGN="LEFT">
                 {% set gauge_score = explain_dic.predicted_score %}
-                {% include 'main/explain_gauge.html' %}
+                {% include 'main/explain_intro_and_gauge.html' %}
             </td>
         </tr>
     </table>

--- a/app/templates/main/explain_baseline.html
+++ b/app/templates/main/explain_baseline.html
@@ -10,9 +10,6 @@
         </tr>
         <tr> 
             <td ALIGN="LEFT">
-                <p>
-                    Based on your answers, the algorithm estimated your current well-being score: <strong>{{ explain_dic.predicted_score }}</strong>.
-                </p>
                 {% set gauge_score = explain_dic.predicted_score %}
                 {% include 'main/explain_gauge.html' %}
             </td>

--- a/app/templates/main/explain_contextual.html
+++ b/app/templates/main/explain_contextual.html
@@ -10,9 +10,6 @@
         </tr>
         <tr> 
             <td ALIGN="LEFT">
-                <p>
-                    Based on your answers, the algorithm estimated your current well-being score: <strong>{{ explain_dic.predicted_score }}</strong>.
-                </p>
                 {% set gauge_score = explain_dic.predicted_score %}
                 {% include 'main/explain_gauge.html' %}
                 <p>

--- a/app/templates/main/explain_contextual.html
+++ b/app/templates/main/explain_contextual.html
@@ -13,8 +13,7 @@
                 {% set gauge_score = explain_dic.predicted_score %}
                 {% include 'main/explain_intro_and_gauge.html' %}
                 <p>
-                    This score reflects how some of your lifestyle habits influence your overall well-being, based on patterns we've observed in our pilot study with 1,881 participants.
-                    To help you situate yourself, here is the distribution of scores observed during our pilot study:
+                    To help you understand what this number means, here’s how well-being scores were distributed among participants in the pilot study:
                 </p>
                 <ul>
                     <li>

--- a/app/templates/main/explain_contextual.html
+++ b/app/templates/main/explain_contextual.html
@@ -11,7 +11,7 @@
         <tr> 
             <td ALIGN="LEFT">
                 {% set gauge_score = explain_dic.predicted_score %}
-                {% include 'main/explain_gauge.html' %}
+                {% include 'main/explain_intro_and_gauge.html' %}
                 <p>
                     This score reflects how some of your lifestyle habits influence your overall well-being, based on patterns we've observed in our pilot study with 1,881 participants.
                     To help you situate yourself, here is the distribution of scores observed during our pilot study:

--- a/app/templates/main/explain_contextual.html
+++ b/app/templates/main/explain_contextual.html
@@ -10,8 +10,12 @@
         </tr>
         <tr> 
             <td ALIGN="LEFT">
+                {# — Score — #}
                 {% set gauge_score = explain_dic.predicted_score %}
                 {% include 'main/explain_intro_and_gauge.html' %}
+
+                {# — Explanation — #}
+                <h4 class="pnavsub">Why do you have this score?</h4>
                 <p>
                     To help you understand what this number means, here’s how well-being scores were distributed among participants in the pilot study:
                 </p>
@@ -41,6 +45,9 @@
                         {% endif %}
                     </li>
                 </ul>
+
+                {% include 'main/disclaimer.html' %} 
+                
             </td>
         </tr>
     </table>

--- a/app/templates/main/explain_gauge_interactive.html
+++ b/app/templates/main/explain_gauge_interactive.html
@@ -1,3 +1,9 @@
+<p>
+    Based on the new answers you provided, your well-being score has changed from 
+    <strong>{{ explain_dic.previous_predicted_score }}</strong> to 
+    <strong>{{ explain_dic.predicted_score }}</strong>.
+</p>
+
 <div id="gauge-container" style="width:100%; max-width:400px; margin:20px 0;">
     <div style="position:relative; height:30px; background:linear-gradient(to right, #e74c3c, #f1c40f, #27ae60); border-radius:15px;">
         <div id="gauge-marker" style="

--- a/app/templates/main/explain_interactive.html
+++ b/app/templates/main/explain_interactive.html
@@ -13,41 +13,51 @@
         <tr>
             <td ALIGN="LEFT">
                 {% if explain_dic.previous_predicted_score is none %}
+                    {# — Score — #}
                     {% set gauge_score = explain_dic.predicted_score %}
                     {% include 'main/explain_intro_and_gauge.html' %}
-                {% else %}
+
+                    {# — Explanation — #}
+                    <h4 class="pnavsub">Why do you have this score?</h4>
+                    
                     <p>
-                        Based on the new answers you provided, your well-being score has changed from 
-                        <strong>{{ explain_dic.previous_predicted_score }}</strong> to 
-                        <strong>{{ explain_dic.predicted_score }}</strong>.
+                        According to our algorithm, <strong>{{ explain_dic.n_informative }} lifestyle factors</strong> most strongly predict your well-being score.
+                        Below are the questions associated with these {{ explain_dic.n_informative }} factors, along with your previous answers.
                     </p>
+                    <p>
+                        To better understand how these factors shape your well-being, <strong>try adjusting your responses</strong>.
+                        Then, click the <strong>"Repredict"</strong> button to see how your score changes — and explore what matters most for your well-being.
+                    </p>
+
+                {% else %}
+                    {# — Score — #}
                     {% set gauge_score_start = explain_dic.previous_predicted_score %}
                     {% set gauge_score_end = explain_dic.predicted_score %}
                     {% include 'main/explain_gauge_interactive.html' %}
-                {% endif %}
-                <p>
-                    Among all the lifestyle factors you shared, the ones that influence your score the most are:
-                </p>
-                <ul>
-                    <li><strong>Sleep quality</strong></li>
-                    <li><strong>Healthy diet</strong></li>
-                    <li><strong>Social activities</strong></li>
-                    <li><strong>Friendly neighborhood</strong></li>
-                    <li><strong>Volunteering</strong></li>
-                </ul>
-                <p>
-                    To better understand how these factors shape your well-being, try adjusting your answers below.
-                    After adjusting your answers, click the <strong>"Retry"</strong> button to see how your well-being score would change — helping you explore what matters most for your well-being.
-                    You can try as many changes as you like — feel free to explore different combinations before moving on.
 
-                </p>
+                    {# — Retry suggestion — #}
+                    <p>
+                        Feel free to experiment with different combinations of answers before moving on. 
+                    </p>
+                {% endif %}
+                
                 <form action="/explain" method="post">
                     <input type="hidden" name="source_page" value="explain_interactive.html">
                     <input type="hidden" name="previous_predicted_score" value="{{ explain_dic.predicted_score }}">
-                    {% set button_text = "Retry" %}
+                    {% set button_text = "Repredict" %}
                     {% set button_class = "btn-retry" %}
                     {% include 'main/question_blocs.html'%}
                 </form> 
+
+                <br><br>
+                {# — Additionnal factors — #}
+                <h4 class="pnavsub">What about the other factors?</h4>
+                <p>
+                    We highlight only the {{ explain_dic.n_informative }} most predictive factors identified by the algorithm. However, other factors such as time spent in nature, your chronotype, your working environment, etc. may also explain your well-being score.
+                </p>
+                
+                {% include 'main/disclaimer.html' %}
+
             </td>
         </tr>
     </table>    

--- a/app/templates/main/explain_interactive.html
+++ b/app/templates/main/explain_interactive.html
@@ -12,20 +12,19 @@
         </tr>
         <tr>
             <td ALIGN="LEFT">
-                <p>
-                    {% if explain_dic.previous_predicted_score is none %}
-                        Based on your answers, the algorithm estimated your current well-being score: <strong>{{ explain_dic.predicted_score }}</strong>.
-                        {% set gauge_score = explain_dic.predicted_score %}
-                        {% include 'main/explain_gauge.html' %}
-                    {% else %}
+                {% if explain_dic.previous_predicted_score is none %}
+                    {% set gauge_score = explain_dic.predicted_score %}
+                    {% include 'main/explain_gauge.html' %}
+                {% else %}
+                    <p>
                         Based on the new answers you provided, your well-being score has changed from 
                         <strong>{{ explain_dic.previous_predicted_score }}</strong> to 
                         <strong>{{ explain_dic.predicted_score }}</strong>.
-                        {% set gauge_score_start = explain_dic.previous_predicted_score %}
-                        {% set gauge_score_end = explain_dic.predicted_score %}
-                        {% include 'main/explain_gauge_interactive.html' %}
-                    {% endif %}
-                </p>
+                    </p>
+                    {% set gauge_score_start = explain_dic.previous_predicted_score %}
+                    {% set gauge_score_end = explain_dic.predicted_score %}
+                    {% include 'main/explain_gauge_interactive.html' %}
+                {% endif %}
                 <p>
                     Among all the lifestyle factors you shared, the ones that influence your score the most are:
                 </p>

--- a/app/templates/main/explain_interactive.html
+++ b/app/templates/main/explain_interactive.html
@@ -14,7 +14,7 @@
             <td ALIGN="LEFT">
                 {% if explain_dic.previous_predicted_score is none %}
                     {% set gauge_score = explain_dic.predicted_score %}
-                    {% include 'main/explain_gauge.html' %}
+                    {% include 'main/explain_intro_and_gauge.html' %}
                 {% else %}
                     <p>
                         Based on the new answers you provided, your well-being score has changed from 

--- a/app/templates/main/explain_interactive.html
+++ b/app/templates/main/explain_interactive.html
@@ -41,15 +41,17 @@
                     </p>
                 {% endif %}
                 
-                <form action="/explain" method="post">
-                    <input type="hidden" name="source_page" value="explain_interactive.html">
-                    <input type="hidden" name="previous_predicted_score" value="{{ explain_dic.predicted_score }}">
-                    {% set button_text = "Repredict" %}
-                    {% set button_class = "btn-retry" %}
-                    {% include 'main/question_blocs.html'%}
-                </form> 
+                <div style="border: 2px solid #325B7E; border-radius: 10px; padding: 25px 20px; margin: 30px 0;">
+                    <form action="/explain" method="post">
+                        <input type="hidden" name="source_page" value="explain_interactive.html">
+                        <input type="hidden" name="previous_predicted_score" value="{{ explain_dic.predicted_score }}">
+                        {% set button_text = "Repredict" %}
+                        {% set button_class = "btn-retry" %}
+                        {% include 'main/question_blocs.html'%}
+                    </form>
+                </div>
 
-                <br><br>
+                <br>
                 {# — Additionnal factors — #}
                 <h4 class="pnavsub">What about the other factors?</h4>
                 <p>

--- a/app/templates/main/explain_intro_and_gauge.html
+++ b/app/templates/main/explain_intro_and_gauge.html
@@ -1,6 +1,6 @@
 <p>
     Based on a pilot study involving 1,881 participants who answered the same questions as you, we calibrated an algorithm to predict well-being scores. 
-    According to your answers, the algorithm estimates your current well-being score to be: <strong>{{gauge_score}}</strong>.
+    According to your answers, the algorithm predicts your current well-being score to be: <strong>{{gauge_score}}</strong>.
 </p>
 <div style="width:100%; max-width:400px; margin:20px 0;">
     <div style="position:relative; height:30px; background:linear-gradient(to right, #e74c3c, #f1c40f, #27ae60); border-radius:15px;">

--- a/app/templates/main/explain_intro_and_gauge.html
+++ b/app/templates/main/explain_intro_and_gauge.html
@@ -1,5 +1,5 @@
 <p>
-    Based on a pilot study involving nearly 2,000 participants who answered the same questions as you, we calibrated an algorithm to predict well-being scores. 
+    Based on a pilot study involving 1,881 participants who answered the same questions as you, we calibrated an algorithm to predict well-being scores. 
     According to your answers, the algorithm estimates your current well-being score to be: <strong>{{gauge_score}}</strong>.
 </p>
 <div style="width:100%; max-width:400px; margin:20px 0;">

--- a/app/templates/main/explain_intro_and_gauge.html
+++ b/app/templates/main/explain_intro_and_gauge.html
@@ -1,3 +1,7 @@
+<p>
+    Based on a pilot study with almost 2,000 participants who answered the same questions as you, we calibrated an algorithm to predict well-being scores. 
+    According to your answers, the algorithm estimates your current well-being score to be: <strong>{{gauge_score}}</strong>.
+</p>
 <div style="width:100%; max-width:400px; margin:20px 0;">
     <div style="position:relative; height:30px; background:linear-gradient(to right, #e74c3c, #f1c40f, #27ae60); border-radius:15px;">
         <div style="

--- a/app/templates/main/explain_intro_and_gauge.html
+++ b/app/templates/main/explain_intro_and_gauge.html
@@ -1,5 +1,5 @@
 <p>
-    Based on a pilot study with almost 2,000 participants who answered the same questions as you, we calibrated an algorithm to predict well-being scores. 
+    Based on a pilot study involving nearly 2,000 participants who answered the same questions as you, we calibrated an algorithm to predict well-being scores. 
     According to your answers, the algorithm estimates your current well-being score to be: <strong>{{gauge_score}}</strong>.
 </p>
 <div style="width:100%; max-width:400px; margin:20px 0;">

--- a/app/templates/main/explain_quantitative.html
+++ b/app/templates/main/explain_quantitative.html
@@ -11,7 +11,7 @@
         <tr> 
             <td ALIGN="LEFT">
                 {% set gauge_score = explain_dic.predicted_score %}
-                {% include 'main/explain_gauge.html' %}
+                {% include 'main/explain_intro_and_gauge.html' %}
                 <p>
                     It is calculated based on how you answered <strong>{{ explain_dic.n_informative }}</strong> key lifestyle questions. These questions are particularly important because our analysis showed they are the best indicators of well-being. Here's how your score was determined:
                 </p>

--- a/app/templates/main/explain_quantitative.html
+++ b/app/templates/main/explain_quantitative.html
@@ -10,9 +10,6 @@
         </tr>
         <tr> 
             <td ALIGN="LEFT">
-                <p>
-                    Based on your answers, the algorithm estimated your current well-being score: <strong>{{ explain_dic.predicted_score }}</strong>. 
-                </p>
                 {% set gauge_score = explain_dic.predicted_score %}
                 {% include 'main/explain_gauge.html' %}
                 <p>

--- a/app/templates/main/explain_quantitative.html
+++ b/app/templates/main/explain_quantitative.html
@@ -17,7 +17,7 @@
                 {# — Explanation — #}
                 <h4 class="pnavsub">Why do you have this score?</h4>
                 <p>
-                     According to our algorithm, <strong>{{ explain_dic.n_informative }}</strong> lifestyle factors most strongly predict your well-being score. 
+                     According to our algorithm, <strong>{{ explain_dic.n_informative }} lifestyle factors</strong> most strongly predict your well-being score. 
                      Here's how your score was determined:
                 </p>
 

--- a/app/templates/main/explain_quantitative.html
+++ b/app/templates/main/explain_quantitative.html
@@ -10,23 +10,52 @@
         </tr>
         <tr> 
             <td ALIGN="LEFT">
+                {# — Score — #}
                 {% set gauge_score = explain_dic.predicted_score %}
                 {% include 'main/explain_intro_and_gauge.html' %}
+
+                {# — Explanation — #}
+                <h4 class="pnavsub">Why do you have this score?</h4>
                 <p>
-                    It is calculated based on how you answered <strong>{{ explain_dic.n_informative }}</strong> key lifestyle questions. These questions are particularly important because our analysis showed they are the best indicators of well-being. Here's how your score was determined:
+                     According to our algorithm, <strong>{{ explain_dic.n_informative }}</strong> lifestyle factors most strongly predict your well-being score. 
+                     Here's how your score was determined:
                 </p>
-                <p><ol>
-                {% for question_id, (question_label, question_content, _, question_coefficient, question_value, _) in explain_dic.feature_content_dic.items() %}
-                <li><strong>{{ question_content }}</strong>: This contributes <strong>{{ (question_coefficient * question_value) | round  }}</strong> points to your score.</li>
-                {% endfor %}
-                </ol></p>
 
-                <p><strong>Total Contribution:</strong> Adding these factors together: <strong>{{ explain_dic.intermediate_predicted_score }}</strong> points.</p>
+                <ol>
+                    {% for question_id, (question_label, question_content, question_description, question_coefficient, question_value, question_explain) in explain_dic.feature_content_dic.items() %}
+                    <li class="question-item">
+                        <strong>{{ question_content }}</strong> 
+                        <br />
+                        This factor contributes <strong>{{ (question_coefficient * question_value) | round(2) }}</strong> points to your score.
+                        <button class="dropdown-toggle">How is it computed?</button>
+                        <div class="dropdown-content">
+                            <p>
+                                This question is associated with a coefficient of <strong>{{ question_coefficient | round(2)}}</strong> by the algorithm.
+                            </p>
+                            <p>
+                                Your answer to this question was: "<em>{{ question_explain }}</em>".
+                                This answer is associated with a coefficient of <strong>{{ question_value }}</strong> by the algorithm.
+                            </p>
+                            <p>
+                                Therefore, the contribution of this factor to your score is calculated as:
+                                <br>
+                                <strong>{{ question_coefficient | round(2)}} × {{ question_value | round(2)}} = {{ (question_coefficient * question_value) | round(2) }}</strong>
+                            </p>
+                        </div>
+                    </li>
+                    {% endfor %}
+                </ol>
 
-                <p><strong>The Remaining Points:</strong> The rest of your score, 
-                <strong>{{ explain_dic.predicted_score }} - {{ explain_dic.intermediate_predicted_score }}</strong> = <strong>{{ explain_dic.predicted_score - explain_dic.intermediate_predicted_score }}</strong> points, come from your responses to other lifestyle and socio-demographic questions. These questions collectively play a smaller role in the prediction but still provide additional insights into your well-being.</p>
+                <p>Adding these factors together, we obtain <strong>{{ explain_dic.intermediate_predicted_score }}</strong> points.</p>
 
-                <p><strong>Why This Explanation Matters:</strong> This breakdown shows how much each factor influences your score. For instance, the most influential questions highlight the areas where small changes could significantly impact your well-being score.</p>
+                {# — Additionnal factors — #}
+                <h4 class="pnavsub">What about the other factors?</h4>
+                <p>
+                    We detail only the points for the the {{ explain_dic.n_informative }} most predictive factors identified by the algorithm. 
+                    However, the rest of your score, <strong>{{ explain_dic.predicted_score }} - {{ explain_dic.intermediate_predicted_score }}</strong> = <strong>{{ explain_dic.predicted_score - explain_dic.intermediate_predicted_score }}</strong> points, come from other factors such as time spent in nature, your chronotype, your working environment, etc. that may also explain your well-being score.
+                </p>
+
+                {% include 'main/disclaimer.html' %} 
 
             </td>
         </tr>

--- a/app/templates/main/explain_quantitative.html
+++ b/app/templates/main/explain_quantitative.html
@@ -30,10 +30,10 @@
                         <button class="dropdown-toggle">How is it computed?</button>
                         <div class="dropdown-content">
                             <p>
-                                This question is associated with a coefficient of <strong>{{ question_coefficient | round(2)}}</strong> by the algorithm.
+                                This <strong>question</strong> is associated with a coefficient of <strong>{{ question_coefficient | round(2)}}</strong> by the algorithm.
                             </p>
                             <p>
-                                Your answer to this question was: "<em>{{ question_explain }}</em>".
+                                Your <strong>answer</strong> to this question was: "<em>{{ question_explain }}</em>".
                                 This answer is associated with a coefficient of <strong>{{ question_value }}</strong> by the algorithm.
                             </p>
                             <p>

--- a/app/templates/main/explain_quantitative.html
+++ b/app/templates/main/explain_quantitative.html
@@ -34,7 +34,7 @@
                             </p>
                             <p>
                                 Your <strong>answer</strong> to this question was: "<em>{{ question_explain }}</em>".
-                                This answer is associated with a coefficient of <strong>{{ question_value }}</strong> by the algorithm.
+                                This answer is associated with a coefficient of <strong>{{ question_value | round(2)}}</strong> by the algorithm.
                             </p>
                             <p>
                                 Therefore, the contribution of this factor to your score is calculated as:

--- a/app/templates/main/explain_textual.html
+++ b/app/templates/main/explain_textual.html
@@ -11,7 +11,7 @@
         <tr> 
             <td ALIGN="LEFT">
                 {% set gauge_score = explain_dic.predicted_score %}
-                {% include 'main/explain_gauge.html' %}
+                {% include 'main/explain_intro_and_gauge.html' %}
                 <p>
                     This score reflects how some of your lifestyle habits influence your overall well-being, based on patterns we've observed in a large group of people. Let me explain this without technical jargon:
                 </p>

--- a/app/templates/main/explain_textual.html
+++ b/app/templates/main/explain_textual.html
@@ -10,13 +10,14 @@
         </tr>
         <tr> 
             <td ALIGN="LEFT">
+                {# — Score — #}
                 {% set gauge_score = explain_dic.predicted_score %}
                 {% include 'main/explain_intro_and_gauge.html' %}
+
+                {# — Explanation — #}
+                <h4 class="pnavsub">Why do you have this score?</h4>
                 <p>
-                    This score reflects how some of your lifestyle habits influence your overall well-being, based on patterns we've observed in a large group of people. Let me explain this without technical jargon:
-                </p>
-                <p>
-                    We found that <strong>{{ explain_dic.n_informative }}</strong> key questions had the most impact on your well-being score:
+                     According to our algorithm, <strong>{{ explain_dic.n_informative }}</strong> lifestyle factors most strongly predict your well-being score:
                 </p>
                 <ol>
                     {% for question_id, (question_label, question_content, question_description, _, _, question_explain) in explain_dic.feature_content_dic.items() %}
@@ -31,13 +32,14 @@
                     </li>
                     {% endfor %}
                 </ol>
+
+                {# — Additionnal factors — #}
+                <h4 class="pnavsub">What about the other factors?</h4>
                 <p>
-                    These factors combined explain most of your score. The remaining points come from other areas in your life, such as your daily stress levels, eating habits, or work-life balance. These areas are harder to capture but still contribute to your overall well-being.
-                </p>
-                <p>
-                    The goal of this tool is to help you understand where you might focus your energy to improve your well-being. Based on your responses, small changes in these areas could make a meaningful difference to your well-being.
+                    We highlight only the {{ explain_dic.n_informative }} most predictive factors identified by the algorithm. However, other factors such as time spent in nature, your chronotype, your working environment, etc. may also explain your well-being score.
                 </p>
                 
+                {% include 'main/disclaimer.html' %}                
 
             </td>
         </tr>

--- a/app/templates/main/explain_textual.html
+++ b/app/templates/main/explain_textual.html
@@ -10,9 +10,6 @@
         </tr>
         <tr> 
             <td ALIGN="LEFT">
-                <p>
-                    Based on your answers, the algorithm estimated your current well-being score: <strong>{{ explain_dic.predicted_score }}</strong>. 
-                </p>
                 {% set gauge_score = explain_dic.predicted_score %}
                 {% include 'main/explain_gauge.html' %}
                 <p>

--- a/app/templates/main/explain_textual.html
+++ b/app/templates/main/explain_textual.html
@@ -17,7 +17,7 @@
                 {# — Explanation — #}
                 <h4 class="pnavsub">Why do you have this score?</h4>
                 <p>
-                     According to our algorithm, <strong>{{ explain_dic.n_informative }}</strong> lifestyle factors most strongly predict your well-being score:
+                     According to our algorithm, <strong>{{ explain_dic.n_informative }} lifestyle factors</strong> most strongly predict your well-being score:
                 </p>
                 <ol>
                     {% for question_id, (question_label, question_content, question_description, _, _, question_explain) in explain_dic.feature_content_dic.items() %}

--- a/app/templates/main/explain_visual.html
+++ b/app/templates/main/explain_visual.html
@@ -12,10 +12,24 @@
         </tr>
         <tr>
             <td ALIGN="LEFT">
+                {# — Score — #}
                 {% set gauge_score = explain_dic.predicted_score %}
                 {% include 'main/explain_intro_and_gauge.html' %}
-                <p>The radar chart highlights 
-                    <strong>{{ explain_dic.n_informative }}</strong> key aspects of your lifestyle that significantly influence this score. Let me explain how these factors contribute to your overall well-being:
+
+                {# — Key factors — #}
+                <h4 class="pnavsub">Key factors</h4>
+                <p>
+                    We found <strong>{{ explain_dic.n_informative }}</strong> factors that explain the majority of your score:
+                    <ol>
+                    {% for question_id, question_data in explain_dic.feature_content_dic.items() %}
+                    <li>
+                        <strong>{{ question_data[0] }}</strong>: {{ question_data[1] }}
+                    </li>
+                    {% endfor %}
+                </ol>
+                </p>
+                <p>
+                    Each axis of the radar chart represents your answers to these questions, showing how each factor contributes to your overall well-being score. The distance from the center indicates how well you are doing in the factor mentionned.
                 </p>
 
                 <div class="chart-container">
@@ -26,18 +40,10 @@
                         alt="Radar Chart">
                 </div>
 
-                <ol>
-                    {% for question_id, question_data in explain_dic.feature_content_dic.items() %}
-                    <li>
-                        <strong>{{ question_data[0] }}</strong>: {{ question_data[1] }}
-                    </li>
-                    {% endfor %}
-                </ol>
+                {# — Additionnal factors — #}
+                <h4 class="pnavsub">Additionnal factors</h4>
                 <p>
-                    These factors together explain the majority of your score. The radar chart visually represents how well-balanced these areas are in your life and suggests areas where small improvements could lead to better well-being.
-                </p>
-                <p>
-                    The remaining points come from other aspects of your lifestyle and environment that are not captured in the radar chart but still contribute to your overall well-being.
+                    
                 </p>
                 <p>
                     This tool aims to help you identify which aspects of your lifestyle have the most influence on your well-being and where you might want to focus your attention to feel better overall. Small, consistent changes in these areas could make a meaningful difference.

--- a/app/templates/main/explain_visual.html
+++ b/app/templates/main/explain_visual.html
@@ -13,7 +13,7 @@
         <tr>
             <td ALIGN="LEFT">
                 {% set gauge_score = explain_dic.predicted_score %}
-                {% include 'main/explain_gauge.html' %}
+                {% include 'main/explain_intro_and_gauge.html' %}
                 <p>The radar chart highlights 
                     <strong>{{ explain_dic.n_informative }}</strong> key aspects of your lifestyle that significantly influence this score. Let me explain how these factors contribute to your overall well-being:
                 </p>

--- a/app/templates/main/explain_visual.html
+++ b/app/templates/main/explain_visual.html
@@ -12,9 +12,6 @@
         </tr>
         <tr>
             <td ALIGN="LEFT">
-                <p>
-                    Based on your answers, the algorithm estimated your current well-being score: <strong>{{ explain_dic.predicted_score }}</strong>. 
-                </p>
                 {% set gauge_score = explain_dic.predicted_score %}
                 {% include 'main/explain_gauge.html' %}
                 <p>The radar chart highlights 

--- a/app/templates/main/explain_visual.html
+++ b/app/templates/main/explain_visual.html
@@ -16,14 +16,14 @@
                 {% set gauge_score = explain_dic.predicted_score %}
                 {% include 'main/explain_intro_and_gauge.html' %}
 
-                {# — Radar chart — #}
+                {# — Explanation — #}
                 <h4 class="pnavsub">Why do you have this score?</h4>
                 <p>
-                    The radar chart represents the <strong>{{ explain_dic.n_informative }}</strong> lifestyle factors that most strongly predict your well-being score according to our algorithm.
-                    Each axis corresponds to one of these key factors, and your position on the axis reflects how well you're doing in that area based on your answers.
+                    According to our algorithm, <strong>{{ explain_dic.n_informative }}</strong> lifestyle factors most strongly predict your well-being score.
+                    Each axis of the radar chart corresponds to one of these key factors, and the position on the axis reflects how well you're doing in that area based on your answers.
                 <br>
                     The <strong>outer edge</strong> of the chart represents the <strong>best possible score</strong> for that factor, while the <strong>center</strong> represents the <strong>worst possible score</strong>.
-                    Therefore, <strong>points near the center</strong> suggest there may be <strong>room for improvement</strong> for that factor.
+                    Therefore, <strong>being positioned near the center of the circle</strong> suggest there may be <strong>room for improvement</strong> for that factor.
                 </p>
 
                 <div class="chart-container">

--- a/app/templates/main/explain_visual.html
+++ b/app/templates/main/explain_visual.html
@@ -19,7 +19,7 @@
                 {# — Key factors — #}
                 <h4 class="pnavsub">Key factors</h4>
                 <p>
-                    We found <strong>{{ explain_dic.n_informative }}</strong> factors that explain the majority of your score:
+                    According to our algorithm, the <strong>{{ explain_dic.n_informative }}</strong> lifestyle factors that most strongly predict your well-being score are:
                     <ol>
                     {% for question_id, question_data in explain_dic.feature_content_dic.items() %}
                     <li>
@@ -28,8 +28,11 @@
                     {% endfor %}
                 </ol>
                 </p>
+
+                {# — Radar chart — #}
+                <h4 class="pnavsub">Radar chart visualization</h4>
                 <p>
-                    Each axis of the radar chart represents your answers to these questions, showing how each factor contributes to your overall well-being score. The distance from the center indicates how well you are doing in the factor mentionned.
+                    Each axis of the radar chart represents one of the key factors above. The position on each axis shows how well you are doing in that area, based on your answers to the corresponding questions. Therefore, the <strong>closer</strong> the point on an axis is <strong>to the center</strong> of the chart, the more <strong>room there is for improvement</strong> in that factor.
                 </p>
 
                 <div class="chart-container">
@@ -40,13 +43,13 @@
                         alt="Radar Chart">
                 </div>
 
-                {# — Additionnal factors — #}
-                <h4 class="pnavsub">Additionnal factors</h4>
+                {# — Disclaimer — #}
+                <h4 class="pnavsub">About this tool </h4>
                 <p>
-                    
+                    This chart highlights only the {{ explain_dic.n_informative }} most predictive factors identified by the algorithm. However, other factors may also impact your well-being score.
                 </p>
                 <p>
-                    This tool aims to help you identify which aspects of your lifestyle have the most influence on your well-being and where you might want to focus your attention to feel better overall. Small, consistent changes in these areas could make a meaningful difference.
+                    The insights provided here are based on the algorithm trained in our pilot study and are not intended to replace professional advice. For any concerns about your mental health, we encourage you to speak with a qualified healthcare provider.
                 </p>
             </td>
         </tr>

--- a/app/templates/main/explain_visual.html
+++ b/app/templates/main/explain_visual.html
@@ -48,7 +48,7 @@
                 {# — Additionnal factors — #}
                 <h4 class="pnavsub">What about the other factors?</h4>
                 <p>
-                    This chart highlights only the {{ explain_dic.n_informative }} most predictive factors identified by the algorithm. However, other factors such as time spent in natural environment, your chronotype, your working environment, etc. may also explain your well-being score.
+                    This chart highlights only the {{ explain_dic.n_informative }} most predictive factors identified by the algorithm. However, other factors such as time spent in nature, your chronotype, your working environment, etc. may also explain your well-being score.
                 </p>
                 
                 {% include 'main/disclaimer.html' %}

--- a/app/templates/main/explain_visual.html
+++ b/app/templates/main/explain_visual.html
@@ -48,7 +48,7 @@
                 {# — Additionnal factors — #}
                 <h4 class="pnavsub">What about the other factors?</h4>
                 <p>
-                    This chart highlights only the {{ explain_dic.n_informative }} most predictive factors identified by the algorithm. However, other factors may also impact your well-being score.
+                    This chart highlights only the {{ explain_dic.n_informative }} most predictive factors identified by the algorithm. However, other factors such as time spent in natural environment, your chronotype, your working environment, etc. may also explain your well-being score.
                 </p>
                 
                 {% include 'main/disclaimer.html' %}

--- a/app/templates/main/explain_visual.html
+++ b/app/templates/main/explain_visual.html
@@ -51,7 +51,7 @@
                     This chart highlights only the {{ explain_dic.n_informative }} most predictive factors identified by the algorithm. However, other factors may also impact your well-being score.
                 </p>
                 
-                
+                {% include 'main/disclaimer.html' %}
 
             </td>
         </tr>

--- a/app/templates/main/explain_visual.html
+++ b/app/templates/main/explain_visual.html
@@ -19,7 +19,7 @@
                 {# — Explanation — #}
                 <h4 class="pnavsub">Why do you have this score?</h4>
                 <p>
-                    According to our algorithm, <strong>{{ explain_dic.n_informative }}</strong> lifestyle factors most strongly predict your well-being score.
+                    According to our algorithm, <strong>{{ explain_dic.n_informative }} lifestyle factors</strong> most strongly predict your well-being score.
                     Each axis of the radar chart corresponds to one of these key factors, and the position on the axis reflects how well you're doing in that area based on your answers.
                 <br>
                     The <strong>outer edge</strong> of the chart represents the <strong>best possible score</strong> for that factor, while the <strong>center</strong> represents the <strong>worst possible score</strong>.

--- a/app/templates/main/explain_visual.html
+++ b/app/templates/main/explain_visual.html
@@ -16,23 +16,14 @@
                 {% set gauge_score = explain_dic.predicted_score %}
                 {% include 'main/explain_intro_and_gauge.html' %}
 
-                {# — Key factors — #}
-                <h4 class="pnavsub">Key factors</h4>
-                <p>
-                    According to our algorithm, the <strong>{{ explain_dic.n_informative }}</strong> lifestyle factors that most strongly predict your well-being score are:
-                    <ol>
-                    {% for question_id, question_data in explain_dic.feature_content_dic.items() %}
-                    <li>
-                        <strong>{{ question_data[0] }}</strong>: {{ question_data[1] }}
-                    </li>
-                    {% endfor %}
-                </ol>
-                </p>
-
                 {# — Radar chart — #}
-                <h4 class="pnavsub">Radar chart visualization</h4>
+                <h4 class="pnavsub">Why do you have this score?</h4>
                 <p>
-                    Each axis of the radar chart represents one of the key factors above. The position on each axis shows how well you are doing in that area, based on your answers to the corresponding questions. Therefore, the <strong>closer</strong> the point on an axis is <strong>to the center</strong> of the chart, the more <strong>room there is for improvement</strong> in that factor.
+                    The radar chart represents the <strong>{{ explain_dic.n_informative }}</strong> lifestyle factors that most strongly predict your well-being score according to our algorithm.
+                    Each axis corresponds to one of these key factors, and your position on the axis reflects how well you're doing in that area based on your answers.
+                <br>
+                    The <strong>outer edge</strong> of the chart represents the <strong>best possible score</strong> for that factor, while the <strong>center</strong> represents the <strong>worst possible score</strong>.
+                    Therefore, <strong>points near the center</strong> suggest there may be <strong>room for improvement</strong> for that factor.
                 </p>
 
                 <div class="chart-container">
@@ -43,14 +34,25 @@
                         alt="Radar Chart">
                 </div>
 
-                {# — Disclaimer — #}
-                <h4 class="pnavsub">About this tool </h4>
+                {# — Legend of key factors — #}
+                <p>
+                    <strong>Radar chart legend</strong>
+                </p>
+                <p>
+                    {% for question_id, question_data in explain_dic.feature_content_dic.items() %}
+                        {{ question_data[0] }} - {{ question_data[1] }}<br>
+                    {% endfor %}
+                </p>
+                <br>
+
+                {# — Additionnal factors — #}
+                <h4 class="pnavsub">What about the other factors?</h4>
                 <p>
                     This chart highlights only the {{ explain_dic.n_informative }} most predictive factors identified by the algorithm. However, other factors may also impact your well-being score.
                 </p>
-                <p>
-                    The insights provided here are based on the algorithm trained in our pilot study and are not intended to replace professional advice. For any concerns about your mental health, we encourage you to speak with a qualified healthcare provider.
-                </p>
+                
+                
+
             </td>
         </tr>
     </table>


### PR DESCRIPTION
- Add a disclaimer on each explain type with an HTML file 'disclaimer'
- Put the intro sentence in the HTML file 'explain_intro_and_gauge'
- Update the structure of each explain type to be consistent between the different types
- For explain interactive, add a border for the question of sandbox, modify the intro text depending if it is the first or the second time in computing of score, and rename the button
- For explain quantitative, add a dropdown to detail the computing of eash point
- For explain visual, detail the understanding of the chart