### PR TITLE
streamlit to visualize users per phase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,3 +93,6 @@ download-files:
 
 dump-database:
 	poetry run python -c "from scripts.export_db import export_database_to_csv; export_database_to_csv()"
+
+visualize-logs:
+	poetry run python -c "from scripts.view_databases import logs_to_user_status; logs_to_user_status()"

--- a/Makefile
+++ b/Makefile
@@ -95,4 +95,4 @@ dump-database:
 	poetry run python -c "from scripts.export_db import export_database_to_csv; export_database_to_csv()"
 
 visualize-logs:
-	poetry run python -c "from scripts.view_databases import logs_to_user_status; logs_to_user_status()"
+	poetry run python -c "from scripts.streamlit_logs import logs_to_user_status; logs_to_user_status()"

--- a/Makefile
+++ b/Makefile
@@ -95,4 +95,4 @@ dump-database:
 	poetry run python -c "from scripts.export_db import export_database_to_csv; export_database_to_csv()"
 
 visualize-logs:
-	poetry run python -c "from scripts.streamlit_logs import logs_to_user_status; logs_to_user_status()"
+	poetry run streamlit run scripts/streamlit_logs.py

--- a/scripts/streamlit_logs.py
+++ b/scripts/streamlit_logs.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import os
 import pandas as pd
 import streamlit as st
-import matplotlib.pyplot as plt
+import plotly.express as px
 
 
 # Load the .env file
@@ -34,6 +34,9 @@ def logs_to_user_status():
     
     return last_phase
 
+# Page title
+st.title("Histogram of users per phase")
+
 # phase order
 phase_order = [
     "login", "consent", "sociodemo", "knowledge_before", "lifestyle",
@@ -42,16 +45,21 @@ phase_order = [
 
 # dict with phase_id for each user_id
 last_phase_dict = logs_to_user_status()
-phase_series = pd.Series(list(last_phase_dict.values()))
-phase_series = pd.Categorical(phase_series, categories=phase_order, ordered=True)
 
 # count per phase
-phase_counts = pd.Series(phase_series).value_counts().reindex(phase_order, fill_value=0).astype(int)
+phase_counts = pd.Series(last_phase_dict).value_counts().reindex(phase_order, fill_value=0).astype(int)
 
 # Display the histogram of user phases
-st.title("Histogram of users per phase")
-st.write("Distribution of last phase_id for users:")
-st.bar_chart(phase_counts)
+df_plot = pd.DataFrame({
+    "Phase": phase_order,
+    "Users": phase_counts.values
+})
+
+fig = px.bar(df_plot, x="Phase", y="Users",
+             labels={"Phase": "Phase", "Users": "Number of users"},
+             title="Number of users per phase")
+
+st.plotly_chart(fig)
 
 # Dropdown to select a user and display their last phase
 st.header("Check last phase for a specific user")
@@ -60,3 +68,4 @@ selected_user = st.selectbox("Select a user_id", user_ids)
 
 if selected_user:
     st.write(f"User `{selected_user}` has finished phase: **{last_phase_dict[selected_user]}**")
+    

--- a/scripts/streamlit_logs.py
+++ b/scripts/streamlit_logs.py
@@ -34,11 +34,19 @@ def logs_to_user_status():
     
     return last_phase
 
-# Streamlit app to display the histogram of user phases
-st.title("Histogram of Last Phase per User")
+# phase order
+phase_order = [
+    "login", "consent", "sociodemo", "knowledge_before", "lifestyle",
+    "explain", "satisfaction", "intent", "knowledge_after", "essaim", "merci"
+]
 
+# dict with phase_id for each user_id
 last_phase_dict = logs_to_user_status()
 phase_series = pd.Series(list(last_phase_dict.values()))
+phase_series = pd.Categorical(phase_series, categories=phase_order, ordered=True)
+
+# Streamlit app to display the histogram of user phases
+st.title("Histogram of Last Phase per User")
 
 st.write("Distribution of last phase_id for users:")
 st.bar_chart(phase_series.value_counts().sort_index())

--- a/scripts/streamlit_logs.py
+++ b/scripts/streamlit_logs.py
@@ -3,6 +3,7 @@ from dotenv import load_dotenv
 from pathlib import Path
 import os
 import pandas as pd
+import streamlit as st
 
 
 # Load the .env file
@@ -30,7 +31,14 @@ def logs_to_user_status():
         .set_index('user_id')['phase_id']
         .to_dict()
     )
-
-    print(last_phase) 
     
     return last_phase
+
+# Streamlit app to display the histogram of user phases
+st.title("Histogram of Last Phase per User")
+
+last_phase_dict = logs_to_user_status()
+phase_series = pd.Series(list(last_phase_dict.values()))
+
+st.write("Distribution of last phase_id for users:")
+st.bar_chart(phase_series.value_counts().sort_index())

--- a/scripts/streamlit_logs.py
+++ b/scripts/streamlit_logs.py
@@ -1,9 +1,9 @@
-
 from dotenv import load_dotenv
 from pathlib import Path
 import os
 import pandas as pd
 import streamlit as st
+import matplotlib.pyplot as plt
 
 
 # Load the .env file
@@ -45,8 +45,10 @@ last_phase_dict = logs_to_user_status()
 phase_series = pd.Series(list(last_phase_dict.values()))
 phase_series = pd.Categorical(phase_series, categories=phase_order, ordered=True)
 
-# Streamlit app to display the histogram of user phases
-st.title("Histogram of Last Phase per User")
+# count per phase
+phase_counts = pd.Series(phase_series).value_counts().reindex(phase_order, fill_value=0).astype(int)
 
+# Streamlit to display the histogram of user phases
+st.title("Histogram of users per phase")
 st.write("Distribution of last phase_id for users:")
-st.bar_chart(phase_series.value_counts().sort_index())
+st.bar_chart(phase_counts)

--- a/scripts/streamlit_logs.py
+++ b/scripts/streamlit_logs.py
@@ -48,7 +48,15 @@ phase_series = pd.Categorical(phase_series, categories=phase_order, ordered=True
 # count per phase
 phase_counts = pd.Series(phase_series).value_counts().reindex(phase_order, fill_value=0).astype(int)
 
-# Streamlit to display the histogram of user phases
+# Display the histogram of user phases
 st.title("Histogram of users per phase")
 st.write("Distribution of last phase_id for users:")
 st.bar_chart(phase_counts)
+
+# Dropdown to select a user and display their last phase
+st.header("Check last phase for a specific user")
+user_ids = sorted(last_phase_dict.keys())
+selected_user = st.selectbox("Select a user_id", user_ids)
+
+if selected_user:
+    st.write(f"User `{selected_user}` has finished phase: **{last_phase_dict[selected_user]}**")

--- a/scripts/streamlit_logs.py
+++ b/scripts/streamlit_logs.py
@@ -1,0 +1,36 @@
+
+from dotenv import load_dotenv
+from pathlib import Path
+import os
+import pandas as pd
+
+
+# Load the .env file
+load_dotenv()
+
+# Log file
+LOG_FILENAME = 'Log.csv'
+
+
+def logs_to_user_status():
+
+    # Load the log file
+    track_path = Path(os.getenv("DATA_TRACK_PATH"))
+    log_file = track_path / LOG_FILENAME
+    log_df = pd.read_csv(log_file, delimiter=",")
+
+    # Convert timestamp to datetime
+    log_df['timestamp'] = pd.to_datetime(log_df['timestamp'])
+
+    # For each user, get the last phase they were in and create a dictionary mapping user_id to phase_id
+    last_phase = (
+        log_df.sort_values('timestamp')
+        .groupby('user_id')
+        .tail(1)
+        .set_index('user_id')['phase_id']
+        .to_dict()
+    )
+
+    print(last_phase) 
+    
+    return last_phase

--- a/scripts/streamlit_logs.py
+++ b/scripts/streamlit_logs.py
@@ -69,3 +69,11 @@ selected_user = st.selectbox("Select a user_id", user_ids)
 if selected_user:
     st.write(f"User `{selected_user}` has finished phase: **{last_phase_dict[selected_user]}**")
     
+    # Display all logs for this user
+    track_path = Path(os.getenv("DATA_TRACK_PATH"))
+    log_file = track_path / LOG_FILENAME
+    log_df = pd.read_csv(log_file, delimiter=",")
+    user_logs = log_df[log_df['user_id'] == selected_user]
+
+    st.subheader("All logs for selected user")
+    st.dataframe(user_logs)

--- a/scripts/view_databases.py
+++ b/scripts/view_databases.py
@@ -5,9 +5,18 @@ import csv
 from app.models import User, Log, Question, Answer
 from app import create_app
 from app import db
+from dotenv import load_dotenv
+from pathlib import Path
+import os
 
 
 app = create_app()
+
+# Load the .env file
+load_dotenv()
+
+# Log file
+LOG_FILENAME = 'Log.csv'
 
 
 def display_users():
@@ -45,3 +54,26 @@ def display_activity():
             logs = db.session.scalars(query).all()
             for log in logs:
                 print(log)
+
+def logs_to_user_status():
+
+    # Load the log file
+    track_path = Path(os.getenv("DATA_TRACK_PATH"))
+    log_file = track_path / LOG_FILENAME
+    log_df = pd.read_csv(log_file, delimiter=",")
+
+    # Convert timestamp to datetime
+    log_df['timestamp'] = pd.to_datetime(log_df['timestamp'])
+
+    # For each user, get the last phase they were in and create a dictionary mapping user_id to phase_id
+    last_phase = (
+        log_df.sort_values('timestamp')
+        .groupby('user_id')
+        .tail(1)
+        .set_index('user_id')['phase_id']
+        .to_dict()
+    )
+
+    print(last_phase) 
+    
+    return last_phase

--- a/scripts/view_databases.py
+++ b/scripts/view_databases.py
@@ -1,22 +1,11 @@
 from flask import Flask, render_template, request, make_response
-import pandas as pd
 import sqlite3
-import csv
 from app.models import User, Log, Question, Answer
 from app import create_app
 from app import db
-from dotenv import load_dotenv
-from pathlib import Path
-import os
 
 
 app = create_app()
-
-# Load the .env file
-load_dotenv()
-
-# Log file
-LOG_FILENAME = 'Log.csv'
 
 
 def display_users():
@@ -54,26 +43,3 @@ def display_activity():
             logs = db.session.scalars(query).all()
             for log in logs:
                 print(log)
-
-def logs_to_user_status():
-
-    # Load the log file
-    track_path = Path(os.getenv("DATA_TRACK_PATH"))
-    log_file = track_path / LOG_FILENAME
-    log_df = pd.read_csv(log_file, delimiter=",")
-
-    # Convert timestamp to datetime
-    log_df['timestamp'] = pd.to_datetime(log_df['timestamp'])
-
-    # For each user, get the last phase they were in and create a dictionary mapping user_id to phase_id
-    last_phase = (
-        log_df.sort_values('timestamp')
-        .groupby('user_id')
-        .tail(1)
-        .set_index('user_id')['phase_id']
-        .to_dict()
-    )
-
-    print(last_phase) 
-    
-    return last_phase


### PR DESCRIPTION
- create streamlit_logs.py to visualize in a streamlit the number users per phase_id and the logs for a specific user. It takes the Log.csv file from the DATA_TRACK_PATH written in the .env
- In Makefile, add the command visualize-logs to run it